### PR TITLE
Updated connect Dependency / Browserify Compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "osenv": "0.0.3",
     "async": "~0.1.22",
     "open": "0.0.2",
-    "connect": "~2.7.1",
+    "connect": "~3.3.4",
+    "cookie-parser": "~1.3.3",
+    "cookie-session": "~1.1.0",
     "colors": "~0.6.0-1",
     "oauth": "~0.9.10"
   },

--- a/src/node/oauth.js
+++ b/src/node/oauth.js
@@ -5,6 +5,8 @@ var path = require('path');
 var async = require('async');
 var read = require('read');
 var connect = require('connect');
+var cookieParser = require('cookie-parser');
+var cookieSession = require('cookie-session');
 var nconf = require('nconf');
 var osenv = require('osenv');
 var querystring = require('querystring');
@@ -710,8 +712,8 @@ rem.promptOAuth = function (/* api, [params,] callback */) {
     var app = connect();
 
     app
-      .use(connect.cookieParser())
-      .use(connect.cookieSession({
+      .use(cookieParser())
+      .use(cookieSession({
         secret: String(Math.random())
       }));
 


### PR DESCRIPTION
This PR makes rem Browserify-compatible. The old version of connect you were using exported like this:

```
module.exports = process.env.CONNECT_COV
  ? require('./lib-cov/connect')
  : require('./lib/connect');
```

`./lib-cov/connect` was a non-existent module, which caused Browserify errors.

I reviewed the rem source code, and adding the `cookieParser` and `cookieSession` middleware seemed to be the only things needed to make rem compatible with connect 3.3.4. I ran `tests/oauth-restore.js` and it worked.
